### PR TITLE
about rich_transcription_postprocess

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ torchaudio
 modelscope
 huggingface
 huggingface_hub
-funasr>=1.1.0
+funasr>=1.1.1
 numpy<=1.26.4


### PR DESCRIPTION
```
from funasr.utils.postprocess_utils import rich_transcription_postprocess
```

This function is available only if funasr has a version is 1.1.1