### PR TITLE
Add support for finding the train_ds.py file in site-packages

### DIFF
--- a/finetune.sh
+++ b/finetune.sh
@@ -43,7 +43,18 @@ DISTRIBUTED_ARGS="
 echo $DISTRIBUTED_ARGS
 
 # funasr trainer path
-train_tool=`dirname $(which funasr)`/train_ds.py
+train_tool=
+if [ -f `dirname $(which funasr)`/train_ds.py ]; then
+    train_tool=`dirname $(which funasr)`/train_ds.py
+elif [ -f `dirname $(which funasr)`/../lib/python*/site-packages/funasr/bin/train_ds.py ]; then
+    train_tool=`dirname $(which funasr)`/../lib/python*/site-packages/funasr/bin/train_ds.py
+else
+    echo "Error: train_ds.py not found in funasr bin directory."
+    exit 1
+fi
+ABSOLUTE_PATH=$(cd $(dirname $train_tool); pwd)
+train_tool=${ABSOLUTE_PATH}/train_ds.py
+echo "Using funasr trainer: ${train_tool}"
 
 torchrun $DISTRIBUTED_ARGS \
 ${train_tool} \

--- a/finetune.sh
+++ b/finetune.sh
@@ -43,7 +43,6 @@ DISTRIBUTED_ARGS="
 echo $DISTRIBUTED_ARGS
 
 # funasr trainer path
-train_tool=
 if [ -f `dirname $(which funasr)`/train_ds.py ]; then
     train_tool=`dirname $(which funasr)`/train_ds.py
 elif [ -f `dirname $(which funasr)`/../lib/python*/site-packages/funasr/bin/train_ds.py ]; then


### PR DESCRIPTION
At least on my system and at least when running from a VM, the `which funasr` returns the bin directory for the venv, which does not have the train_ds.py file in it.  However, the bin folder that **does** have the train_ds.py file in it can be found relative to `dirname $(which funasr)`.  if train_ds.py can't be found, this code attempts to find it in lib/site-packages/funasr/bin