### PR TITLE
Fix batch inference error with timestamp

### DIFF
--- a/model.py
+++ b/model.py
@@ -896,7 +896,7 @@ class SenseVoiceSmall(nn.Module):
                 align = ctc_forced_align(
                     logits_speech.unsqueeze(0).float(),
                     torch.Tensor(token_int[4:]).unsqueeze(0).long().to(logits_speech.device),
-                    (encoder_out_lens-4).long(),
+                    (encoder_out_lens-4).long()[i],
                     torch.tensor(len(token_int)-4).unsqueeze(0).long().to(logits_speech.device),
                     ignore_id=self.ignore_id,
                 )


### PR DESCRIPTION
During batch inference with timestamps, a tensor access out-of-bounds issue consistently occurs. It has been identified that when obtaining the timestamp, the input to the `ctc_forced_align` function should be a single number, but in reality, a list is being input. 