### PR TITLE
Add Docker and Docker Compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# ======================================================
+#   FunASR SenseVoiceSmall Inference Server
+# ======================================================
+FROM pytorch/pytorch:2.3.1-cuda12.1-cudnn8-runtime
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+	ffmpeg libsndfile1 git && \
+	rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+RUN ls -la /app
+# Copy only requirements first
+COPY requirements.txt /app/
+
+# Install dependencies (cached if requirements.txt didn't change)
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Now copy the rest of your code
+COPY . /app
+
+
+# Optional: preload model weights during build (saves runtime download)
+# RUN python -c "from funasr import AutoModel; AutoModel(model='iic/SenseVoiceSmall')"
+
+# Expose FastAPI port
+EXPOSE 50000
+
+# Environment variables
+ENV SENSEVOICE_DEVICE=auto
+ENV PYTHONUNBUFFERED=1
+ENV MODELSCOPE_CACHE=/models
+
+# Create model cache directory (helps reuse between restarts)
+RUN mkdir -p /models
+
+# Start FastAPI app
+CMD ["uvicorn", "api:app", "--host", "0.0.0.0", "--port", "50000"]

--- a/README.md
+++ b/README.md
@@ -245,7 +245,30 @@ fastapi run --port 50000
 git clone https://github.com/alibaba/FunASR.git && cd FunASR
 pip3 install -e ./
 ```
+## 🐳 Docker Support
 
+SenseVoice can be built and run using Docker to simplify setup, ensure reproducibility, and support both CPU and GPU inference.
+
+### Build with Docker
+```bash
+docker build -t sensevoice .
+```
+
+### Run (GPU – default)
+```bash
+docker run --gpus all -p 50000:50000 sensevoice
+```
+### Run (CPU-only)
+```bash
+docker run -e SENSEVOICE_DEVICE=cpu -p 50000:50000 sensevoice
+```
+### Docker Compose
+Docker Compose provides an easier way to run SenseVoice with persistent model caching, networking etc. 
+
+### Start Stack
+```bash
+docker compose up --build
+```
 ### Data prepare
 
 Data examples

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,24 @@
+name: sense
+
+services:
+  sensevoice:
+    container_name: sensevoice
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      MODELSCOPE_CACHE: /models
+      SENSEVOICE_DEVICE: ${SENSEVOICE_DEVICE:-auto}
+    volumes:
+      - sensevoice-models:/models
+    ports:
+      - "50000:50000"
+    restart: on-failure:5
+    logging:
+      options:
+        max-size: "5m"
+        max-file: "3"
+    gpus: all
+
+volumes:
+  sensevoice-models:


### PR DESCRIPTION
## Summary
This PR adds Docker and docker-compose support to SenseVoice to simplify setup,
ensure reproducibility, and enable easier deployment for inference and development.

## Motivation
Current setup requires manual environment configuration.
Docker enables:
- One-command setup
- Consistent runtime across systems
- Easier cloud and GPU deployment

## What’s included
- Dockerfile
- docker-compose.yml
- Documentation in README and docs/docker.md

## How to use
```bash
docker build -t sensevoice .
docker run --rm sensevoice
