### PR TITLE
fix: correct __int__ typo to __init__

### DIFF
--- a/model.py
+++ b/model.py
@@ -18,7 +18,7 @@ from utils.ctc_alignment import ctc_forced_align
 class SinusoidalPositionEncoder(torch.nn.Module):
     """ """
 
-    def __int__(self, d_model=80, dropout_rate=0.1):
+    def __init__(self, d_model=80, dropout_rate=0.1):
         pass
 
     def encode(


### PR DESCRIPTION
## Bug
A class constructor is defined as `def __int__(self, ...)` instead of `def __init__(self, ...)`. This means the method defines integer conversion rather than initialization, so the constructor logic never runs when the class is instantiated.

## Fix
Renamed `__int__` to `__init__`.