### PR TITLE
Fix typo in SinusoidalPositionEncoder.__init__ and remove hardcoded path

### DIFF
--- a/export.py
+++ b/export.py
@@ -40,7 +40,7 @@ except:
     tokenizer = None
 
 # inference
-wav_or_scp = "/Users/shixian/Downloads/asr_example_hotword.wav"
+wav_or_scp = os.path.join(model_path, "example", "en.mp3")
 language_list = [0]
 textnorm_list = [15]
 res = model_bin(wav_or_scp, language_list, textnorm_list, tokenizer=tokenizer)

--- a/model.py
+++ b/model.py
@@ -18,7 +18,7 @@ from utils.ctc_alignment import ctc_forced_align
 class SinusoidalPositionEncoder(torch.nn.Module):
     """ """
 
-    def __int__(self, d_model=80, dropout_rate=0.1):
+    def __init__(self, d_model=80, dropout_rate=0.1):
         pass
 
     def encode(


### PR DESCRIPTION
## Summary

- **model.py**: Fix `__int__` → `__init__` typo in `SinusoidalPositionEncoder` constructor (line 21). The method name `__int__` is a valid Python dunder for integer conversion, so this silently fails to act as the class constructor.
- **export.py**: Replace hardcoded local file path (`/Users/shixian/Downloads/asr_example_hotword.wav`) with a portable path using `os.path.join(model_path, "example", "en.mp3")`, which references the example audio already bundled with the model.

## Test plan

- [x] Verified both changes are minimal and isolated
- [x] The `SinusoidalPositionEncoder` currently works because `encode()` and `forward()` don't depend on instance variables set in `__init__`, but fixing the typo ensures correct behavior if the constructor is extended in the future
- [x] The `export.py` path now uses the model's own example audio, which is guaranteed to exist after model download

🤖 Generated with [Claude Code](https://claude.com/claude-code)