### PR TITLE
fix: correct __init__ typo in SinusoidalPositionEncoder

### DIFF
--- a/model.py
+++ b/model.py
@@ -18,7 +18,7 @@ from utils.ctc_alignment import ctc_forced_align
 class SinusoidalPositionEncoder(torch.nn.Module):
     """ """
 
-    def __int__(self, d_model=80, dropout_rate=0.1):
+    def __init__(self, d_model=80, dropout_rate=0.1):
         pass
 
     def encode(


### PR DESCRIPTION
## Summary

- Fix a typo in `model.py` where `__int__` was incorrectly used instead of `__init__` in the `SinusoidalPositionEncoder` class.

## Problem

The `SinusoidalPositionEncoder` class has a constructor method misspelled as `__int__` instead of `__init__`. This prevents the class from being properly initialized when instantiated directly.

```python
class SinusoidalPositionEncoder(torch.nn.Module):
    """ """

    def __int__(self, d_model=80, dropout_rate=0.1):  # <-- typo here
        pass
```

## Impact

- The class cannot be properly instantiated using `SinusoidalPositionEncoder()`
- While this may go unnoticed if `__init__` is overridden in subclasses, it's a correctness issue that should be fixed

## Solution

Correct the method name from `__int__` to `__init__`.

## Test Plan

- [ ] Verify the class can be instantiated: `encoder = SinusoidalPositionEncoder()`
- [ ] Ensure existing tests still pass
- [ ] No functional changes, only fixing a typo

🤖 Generated with [Claude Code](https://claude.com/claude-code)