### PR TITLE
Add llama.cpp / GGUF runtime for SenseVoiceSmall (CPU / edge)

### DIFF
--- a/runtime/llama.cpp/DESIGN.md
+++ b/runtime/llama.cpp/DESIGN.md
@@ -1,0 +1,337 @@
+# FunASR on llama.cpp / GGUF — Design Document
+
+This document describes the design of the `runtime/llama.cpp` directory: a C++ /
+ggml runtime that runs FunASR models (Fun-ASR-Nano, SenseVoiceSmall, Paraformer)
+without PyTorch, on CPU and edge devices, with quantized GGUF weights. It is the
+counterpart of [whisper.cpp](https://github.com/ggml-org/whisper.cpp) for FunASR.
+
+It is written to be read without the source: it explains *why* the runtime exists,
+*how* each model maps onto ggml, the GGUF weight format, the numerical-fidelity and
+validation methodology, the non-obvious gotchas discovered during the port, and the
+roadmap.
+
+> This is the **shared design document** for the FunASR-on-llama.cpp effort and is
+> kept identical across the FunASR family repos (modelscope/FunASR, Fun-ASR,
+> SenseVoice). The three models share one ggml SAN-M encoder / FSMN / fbank
+> foundation, so the design is documented once here in full; a single-model repo
+> ships only the relevant model directory (§2) but the shared design still applies.
+
+---
+
+## 1. Motivation
+
+FunASR's reference inference runs on PyTorch (and vLLM for the LLM-based models) on
+GPU. That is the right tool for a server that batches many requests and wants to
+saturate a GPU. It is the wrong tool when there is **no GPU and no Python**: a
+laptop, a phone, a Raspberry Pi, an embedded C/C++ application, an offline desktop
+app. There, you want a single self-contained binary, a few hundred MB of quantized
+weights, and CPU SIMD.
+
+[llama.cpp](https://github.com/ggml-org/llama.cpp) / ggml is the de-facto runtime
+for that world (Ollama, LM Studio, whisper.cpp all build on it). Porting FunASR to
+ggml + GGUF makes FunASR run anywhere llama.cpp runs, dramatically widening the
+deployment surface.
+
+| | PyTorch / vLLM (existing) | this runtime (llama.cpp) |
+|---|---|---|
+| target | GPU server, high QPS | CPU / edge / embedded |
+| deps | Python + CUDA + PyTorch | none (C/C++ single binary) |
+| weights | HF fp16/bf16 safetensors | GGUF, 2–8 bit quantization |
+| key tech | PagedAttention, continuous batching | quantization, mmap, CPU SIMD |
+| best for | online service, batch eval | offline, on-device, embedded |
+
+These are complementary, not competing: cloud serving stays on vLLM; this runtime
+covers the on-device / offline case.
+
+---
+
+## 2. System overview
+
+Three models are supported. They share more than they differ — all three use the
+same **SAN-M encoder**, the same **FSMN memory block**, the same **kaldi-compatible
+fbank front end**, and the same ggml building blocks.
+
+```
+                            ┌─────────────────────── shared C++ / ggml ───────────────────────┐
+ audio.wav (16k mono) ──►  kaldi 80-mel fbank + LFR(7/6)  ──►  SAN-M encoder (50 layers, ggml)
+                            └──────────────────────────────────────────────────────────────────┘
+                                                  │ encoder_out [T, 512]
+              ┌───────────────────────────────────┼───────────────────────────────────┐
+   Fun-ASR-Nano                           SenseVoiceSmall                          Paraformer
+   adaptor → audio embeds                 + 4 query tokens                         CIF predictor (host)
+   → inject into Qwen3-0.6B               CTC head → greedy CTC                    → SAN-M decoder (cross-attn)
+   (llama_decode embd path)               → SentencePiece                          → argmax → tokens.json
+   → text                                 → text                                   → text
+```
+
+| model | head / decoder | autoregressive? | output units |
+|---|---|---|---|
+| Fun-ASR-Nano | adaptor + Qwen3-0.6B LLM | yes (LLM) | Qwen3 BPE |
+| SenseVoiceSmall | CTC | no | spectok BPE (25055) |
+| Paraformer | CIF + SAN-M decoder | no (parallel) | char/BPE (8404) |
+
+Directory layout:
+```
+runtime/llama.cpp/
+  README.md            overview
+  DESIGN.md            this document
+  fun-asr-nano/        funasr-cli, funasr-encoder, funasr-embd, export_encoder_gguf.py
+  sensevoice/          funasr-sensevoice, export_sensevoice_gguf.py, detok.py
+  paraformer/          funasr-paraformer, export_paraformer_gguf.py, detok_paraformer.py
+```
+Each model dir holds the llama.cpp example sources (drop-in under `examples/`), a
+GGUF export script, and a model-specific README.
+
+---
+
+## 3. Audio front end (kaldi fbank in C++)
+
+All models use FunASR's `WavFrontend`: kaldi-compatible 80-bin log-mel fbank with a
+hamming window (25 ms / 10 ms), pre-emphasis 0.97, DC removal, 512-pt FFT, then
+**Low-Frame-Rate (LFR)** stacking of 7 frames with stride 6 → a 560-dim feature
+per output frame.
+
+The C++ implementation (`compute_fbank`) reproduces this exactly:
+1. upscale the waveform by 32768 (FunASR feeds int16-range samples to kaldi),
+2. per frame: remove DC offset, pre-emphasis, hamming window, zero-pad to 512,
+3. radix-2 FFT, power spectrum, 80 triangular mel filters (kaldi mel: `1127·ln(1+f/700)`,
+   low 20 Hz, high 8000 Hz), log floor `FLT_EPSILON`,
+4. LFR: left-pad 3 copies of frame 0, stack 7 frames stride 6 → 560-dim.
+
+**Validation:** vs torchaudio kaldi.fbank (dither=0), cosine **1.000000**,
+max_abs_diff 1.75e-3.
+
+**Gotcha — dither.** FunASR's frontend uses `dither=1.0` by default, which adds
+random noise per sample, so the fbank (and everything downstream) is *non-deterministic*
+in the reference. The C++ front end uses dither=0 (deterministic). The model is
+robust to this; it accounts for the small (<1%) cosine gap seen when comparing
+against a dithered reference.
+
+---
+
+## 4. The SAN-M encoder in ggml
+
+The SenseVoice/Paraformer encoder is a 50-layer (Paraformer) or 50+20-layer
+(SenseVoice, with extra `tp_encoders`) **SAN-M** stack. Each layer is pre-norm:
+
+```
+x → LN → SAN-M self-attention → +residual → LN → FFN(relu) → +residual
+```
+
+SAN-M self-attention = standard multi-head attention **plus** an FSMN memory branch
+that runs in parallel on the value projection and is added to the attention output:
+
+```
+q,k,v = split(linear_q_k_v(x))           # one fused projection
+fsmn  = FSMN(v)                           # depthwise conv over time + residual
+attn  = softmax(qkᵀ/√d)·v → linear_out
+out   = attn + fsmn
+```
+
+### 4.1 FSMN as an exact f32 shift-accumulate (design decision)
+
+FSMN is a per-channel (depthwise) 1-D convolution over time with a symmetric
+kernel (size 11). ggml has `ggml_conv_1d_dw`, but it (a) requires the kernel in
+F16 and (b) is flagged as "very likely wrong for some cases" upstream. Both are
+unacceptable for a faithful port.
+
+Instead FSMN is implemented as an **exact f32 shift-accumulate**: the kernel is
+exported as `[K, D]`, the value tensor is zero-padded by `(K-1)/2` on each side
+along time, and the output is `Σ_j kernel[:,j] ⊙ pad(v)[:, t+j]` plus the residual.
+This is 11 element-wise multiply-adds — exact in f32, no F16 rounding, no dependence
+on the questionable conv kernel. It dropped the full-encoder max_abs_diff vs PyTorch
+from 2.93 to **0.0052**.
+
+### 4.2 Position encoding & input scaling
+
+Input is pre-scaled by `√(d_model)=√512` then a sinusoidal position encoding is
+added, with **depth = the input feature dim (560)** and **positions starting at 1**
+(not 0) — both quirks of the FunASR encoder that must be matched exactly.
+
+### 4.3 LayerNorm
+
+eps = 1e-5 everywhere.
+
+**Validation:** first layer cosine 1.0 (max_abs_diff 1.8e-4); full encoder cosine
+**1.000000**, max_abs_diff 5.2e-3 (f32).
+
+---
+
+## 5. Per-model design
+
+### 5.1 Fun-ASR-Nano (encoder + adaptor + LLM)
+
+Pipeline: `fbank → encoder → adaptor → audio embeds [T', 1024] → inject into
+Qwen3-0.6B → text`.
+
+- **LLM half is native.** Qwen3 is supported by llama.cpp, so the extracted
+  Qwen3-0.6B converts to GGUF with the stock `convert_hf_to_gguf.py` and runs
+  unchanged.
+- **Embedding injection.** The audio embeddings are fed into the LLM through
+  `llama_decode`'s embedding-input path — exactly how llava/mtmd inject vision
+  embeddings. The integrated CLI builds the prompt as a *mixed* sequence:
+  `[prefix tokens | audio embeds | suffix tokens]`, where prefix/suffix are fed as
+  token ids (llama.cpp embeds them internally; `llama_tokenize(parse_special=true)`
+  reproduces the exact 18-token prefix) and the audio slot is fed as embeddings.
+- **Low-frame-rate truncation (critical).** The adaptor emits `T'` frames, but the
+  model only uses the first `fake_token_len` of them as audio tokens, where
+  `fake_token_len` derives from the fbank length by a 3-stage `÷2` formula
+  (≈ T'/8). Feeding all `T'` frames is out-of-distribution and makes the LLM loop.
+- **Chunking.** Decoding a long (e.g. 60 s) clip as one segment is OOD and triggers
+  greedy repetition; the CLI's `--chunk 15` splits into windows with a fresh KV per
+  window, dropping micro-CER from ~29% to ~9.5%.
+- **Numerics.** The adaptor output has large magnitude (std ≈ 28, |max| ≈ 1187), so
+  fp16 can overflow; the runtime uses f32/f16 weights with f32 activations.
+
+### 5.2 SenseVoiceSmall (encoder + CTC)
+
+Pipeline: `fbank → prepend 4 query tokens → encoder → CTC head → greedy CTC →
+SentencePiece`.
+
+- **Query tokens.** Four learned embeddings are prepended: `[language(auto), event,
+  emotion, textnorm]` (indices `[0,1,2,15]` for auto/woitn). They are 560-dim and
+  prepended *before* the encoder's `√512` scaling and position encoding.
+- **CTC decode.** `argmax → collapse consecutive → drop blank(0)` → ids → SentencePiece.
+- **Gotcha — no CMVN at inference.** SenseVoice's `inference()` feeds the **raw**
+  log-mel fbank to the encoder; it does **not** apply `am.mvn` CMVN (that code path
+  is unused at inference). Applying CMVN makes the model predict `<|nospeech|>`.
+
+**Validation:** CTC token ids **identical** to PyTorch (108/108 on a clip); text
+matches `AutoModel` exactly.
+
+### 5.3 Paraformer (encoder + CIF + decoder, non-autoregressive)
+
+Pipeline: `fbank → CMVN → encoder → CIF predictor → acoustic embeds [N, 512] →
+SAN-M decoder (cross-attn to encoder) → argmax → tokens.json`.
+
+- **CMVN IS applied** here (unlike SenseVoice): `(fbank + shift)·scale`, per-dim
+  (560), from `am.mvn`.
+- **CIF predictor (runs on host).** Continuous Integrate-and-Fire: a 1-D conv
+  (k=3) + residual + relu + linear → sigmoid → per-frame weight α; then a sequential
+  integrate-and-fire loop emits one acoustic embedding each time the running α-sum
+  crosses 1.0. This both decides the token count and produces the decoder input. It
+  is inherently sequential, so it runs in plain C++ (cheap: ~0.5 G MACs); the
+  encoder and decoder run in ggml.
+- **SAN-M decoder (ggml).** 16 layers, each: `FFN → FSMN self-attention →
+  cross-attention to the encoder output`. The self-attention is **FSMN-only** (no
+  QK attention); cross-attention has q from the decoder slots and k,v from a fused
+  `linear_k_v` of the encoder output. A 17th `decoders3` layer is FFN-only. The
+  decoder FFN has an internal LayerNorm and the second linear has no bias. The
+  layer ordering (FFN *before* the attention inside the residual) is unusual and is
+  matched exactly.
+
+**Validation:** decoded text **identical** to `AutoModel`; CIF token count exact
+(105/105). Encoder cosine 0.997 (residual is the reference's random dither).
+
+**Gotcha — `am.mvn` has three bracketed blocks.** `[Splice idx]`, `[AddShift=shift]`,
+`[Rescale=scale]`. The shift/scale are the two 560-length vectors; naively taking
+the first two blocks grabs `[0]` as the shift and mis-scales everything, which makes
+CIF emit ~4× too few tokens. Parse by length.
+
+---
+
+## 6. GGUF conversion & weight layout
+
+Each model has an `export_*_gguf.py` that packs weights + architecture metadata into
+a single GGUF.
+
+- Tensor names are kept verbatim from the checkpoint (e.g.
+  `encoder.encoders.3.norm1.weight`); the C++ looks them up by name.
+- **FSMN kernels** are transposed from `(D,1,K)` to `[K,D]` at export so the C++
+  shift-accumulate can take a contiguous per-tap `[D]` vector.
+- **CMVN** (`am.mvn`) is parsed to `cmvn.shift` / `cmvn.scale` tensors (Paraformer
+  uses them; SenseVoice ships them but the runtime ignores them).
+- **Quantization.** `--wtype f16` stores the 2-D matmul weights as F16 (norms,
+  biases, FSMN kernels stay f32), halving the encoder GGUF (e.g. 935 → 469 MB) with
+  cosine 0.999999. The Qwen3 LLM uses the standard llama.cpp quantizer (Q8_0 / Q4_K_M).
+
+| file | model | dtype | size |
+|---|---|---|---|
+| funasr-encoder.gguf | Nano | f32 / f16 | 935 / 469 MB |
+| qwen3-0.6b-q8_0.gguf | Nano LLM | Q8_0 | 805 MB |
+| sensevoice-small.gguf | SenseVoice | f32 | 936 MB |
+| paraformer.gguf | Paraformer | f32 | 863 MB |
+
+---
+
+## 7. Numerical fidelity & validation methodology
+
+The port is validated **stage by stage** against the PyTorch reference, using golden
+dumps (fbank, encoder output, adaptor/CIF output, logits/ids) compared by cosine
+similarity and max-abs-diff, then end-to-end by transcription text / CER.
+
+Summary of results (benchmark clip / set):
+
+| stage | metric |
+|---|---|
+| kaldi fbank vs torchaudio | cosine 1.000000 |
+| SAN-M encoder (full) vs PyTorch | cosine 1.000000, max_abs_diff 5e-3 (f32) |
+| SenseVoice CTC ids | identical (108/108) |
+| Paraformer text / token count | identical / 105 = 105 |
+| Fun-ASR-Nano end-to-end CER (same conditions) | C++ 11.68% vs PyTorch 11.70% (Δ0.02%) |
+
+**Why not bit-exact tokens everywhere?** Greedy decoding is chaotic: a ~5e-3
+difference (from ggml-CPU vs torch-GPU matmul summation order) can flip a token on
+a borderline frame, and over a long sequence the paths diverge — *this also happens
+between PyTorch's own GPU and CPU*. What is faithful and what we verify is (a) the
+per-tensor numerics (cosine 1.0) and (b) the **aggregate CER**, which matches the
+reference under identical conditions.
+
+**fp16 caution.** The Fun-ASR-Nano adaptor output magnitude (std ≈ 28) can overflow
+fp16; the audio path is kept in f32 (weights may be f16, activations f32).
+
+---
+
+## 8. Performance
+
+CPU, 8 threads, a 44 s clip:
+- Encoder (50 layers): ~1.2 s.  Paraformer decoder: ~0.5 s.
+- Fun-ASR-Nano end-to-end (with LLM): ~7 s.
+- Fully-quantized footprint (f16 encoder + Q8 LLM) ≈ 1.3 GB.
+
+These are first-correctness numbers; quantizing the encoder and threading/batching
+the front end are open optimizations.
+
+---
+
+## 9. Design decisions & trade-offs
+
+- **ggml for encoder/decoder, host C++ for CIF.** The neural matmul-heavy parts run
+  in ggml (SIMD, future GPU backends); CIF is a sequential scalar loop with data-
+  dependent control flow, so it is clearer and not slower in plain C++.
+- **Exact f32 FSMN instead of `ggml_conv_1d_dw`.** Correctness and f32 precision
+  over reusing a flagged, F16-only op (§4.1).
+- **Prompt as tokens, not a Python embedding table.** The integrated CLI tokenizes
+  the prompt with `llama_tokenize` and lets llama.cpp embed it, so no embedding
+  matrix needs to be shipped or matched (Fun-ASR-Nano).
+- **f32 by default, f16/Q8 opt-in.** f32 is the faithful default; quantization is a
+  size/latency lever the user opts into. (Interestingly, Q8 on the LLM slightly
+  *helps* greedy stability by regularizing away from repetition loops.)
+- **Per-model self-contained example dirs.** Mirrors llama.cpp's `examples/` layout
+  so each builds as a drop-in target; the shared code is duplicated rather than
+  factored to keep each example independently buildable.
+
+---
+
+## 10. Limitations & roadmap
+
+- **WAV input** assumes 16 kHz mono PCM16; arbitrary formats / resampling are TODO.
+- **VAD.** Long audio needs segmentation; today Fun-ASR-Nano uses fixed `--chunk`
+  windows. A real FSMN-VAD front end would close the last ~1.3% CER gap to the
+  production VAD-segmented number and is the highest-value next step.
+- **Single packaged GGUF** (encoder + adaptor + LLM in one file) and a one-command
+  converter.
+- **Encoder/decoder quantization** (Q8 via gguf-py quants), streaming, timestamps
+  (Paraformer CIF peaks give alignment; SenseVoice/Nano via CTC).
+- **Upstream.** The example sources are drop-in for llama.cpp; upstreaming the
+  runtime to ggml-org/llama.cpp (as whisper.cpp-style tools) is a separate track.
+
+---
+
+## 11. Reproducing the validation
+
+Each model dir's README has the build + convert + run quickstart. The export
+scripts read a standard FunASR checkpoint (`model.pt` + `config.yaml` + `am.mvn` /
+tokenizer). To reproduce a stage comparison, dump the corresponding PyTorch tensor
+(`model.encode`, `model.calc_predictor`, …) and compare with cosine / max-abs-diff;
+the numbers in §7 should reproduce within dither noise.

--- a/runtime/llama.cpp/README.md
+++ b/runtime/llama.cpp/README.md
@@ -1,0 +1,56 @@
+# SenseVoiceSmall on llama.cpp / GGUF
+
+Run **SenseVoiceSmall** on the [llama.cpp](https://github.com/ggml-org/llama.cpp) /
+ggml stack — CPU, edge, single binary, no Python at runtime.
+
+SenseVoiceSmall = SAN-M encoder + CTC head (no LLM). The pipeline runs in C++:
+
+```
+WAV (16k mono) → kaldi fbank → prepend 4 query tokens → SAN-M encoder (ggml) →
+CTC head → greedy CTC decode → token ids → SentencePiece detok → text
+```
+
+## Contents
+- `funasr-sensevoice/` — the ggml runtime: WAV → CTC token ids
+- `export_sensevoice_gguf.py` — export encoder + CTC head + query embeddings to GGUF
+- `detok.py` — SentencePiece id → text (the bpe model ships with the checkpoint)
+
+## Build
+```bash
+git clone https://github.com/ggml-org/llama.cpp && cd llama.cpp
+cp -r /path/to/funasr-sensevoice examples/
+echo 'add_subdirectory(funasr-sensevoice)' >> examples/CMakeLists.txt
+cmake -B build -DGGML_NATIVE=ON -DLLAMA_CURL=OFF
+cmake --build build -j --target llama-funasr-sensevoice
+```
+
+## Convert weights to GGUF (one-time)
+```bash
+python export_sensevoice_gguf.py \
+    --model_pt <model>/model.pt --mvn <model>/am.mvn \
+    --out sensevoice-small.gguf                 # f32
+python export_sensevoice_gguf.py --wtype f16 \
+    --model_pt <model>/model.pt --mvn <model>/am.mvn \
+    --out sensevoice-small-f16.gguf             # half size
+```
+
+## Transcribe
+```bash
+build/bin/llama-funasr-sensevoice -m sensevoice-small.gguf -a audio.wav > ids.txt
+python detok.py <model>/chn_jpn_yue_eng_ko_spectok.bpe.model ids.txt
+# → <|zh|><|NEUTRAL|><|Speech|><|woitn|>...transcription...
+```
+
+## Notes & validation
+- The 70-layer SAN-M encoder is shared with the Fun-ASR-Nano runtime and was
+  validated against PyTorch (cosine 1.0). On a benchmark clip the C++ CTC token
+  ids are **identical** to PyTorch (108/108), and the detokenized text matches
+  the FunASR `AutoModel` output exactly.
+- Inference feeds the **raw** log-mel fbank to the encoder; SenseVoice does **not**
+  apply am.mvn CMVN at inference (doing so makes it predict `<|nospeech|>`).
+- Query tokens prepended (4): `[language(auto=0), event=1, emotion=2, textnorm(woitn=15)]`
+  from `embed.weight`; change indices for language/ITN options.
+- LayerNorm eps 1e-5; FSMN = exact f32 shift-accumulate; fbank matches torchaudio.
+- WAV input currently assumes 16 kHz mono PCM16.
+
+Requires a SenseVoiceSmall checkpoint (e.g. `FunAudioLLM/SenseVoiceSmall`).

--- a/runtime/llama.cpp/README.md
+++ b/runtime/llama.cpp/README.md
@@ -100,3 +100,7 @@ detok.py                  SentencePiece id → text (bpe model ships with the ch
 ## Roadmap
 - Built-in SentencePiece detok (drop the Python step); arbitrary WAV formats;
   encoder Q8 quantization; timestamps.
+
+## Further reading
+
+See [DESIGN.md](DESIGN.md) for the full system design — architecture, the shared SAN-M encoder, GGUF weight format, numerical-fidelity and validation methodology, design trade-offs, and gotchas.

--- a/runtime/llama.cpp/README.md
+++ b/runtime/llama.cpp/README.md
@@ -1,56 +1,102 @@
 # SenseVoiceSmall on llama.cpp / GGUF
 
-Run **SenseVoiceSmall** on the [llama.cpp](https://github.com/ggml-org/llama.cpp) /
-ggml stack — CPU, edge, single binary, no Python at runtime.
+Run **SenseVoiceSmall** on the [llama.cpp](https://github.com/ggml-org/llama.cpp)
+/ ggml stack — **CPU, edge, a single binary, no Python at runtime**. Like
+[whisper.cpp](https://github.com/ggml-org/whisper.cpp), but for SenseVoice.
 
-SenseVoiceSmall = SAN-M encoder + CTC head (no LLM). The pipeline runs in C++:
+## Why this exists
+
+SenseVoiceSmall normally runs on PyTorch / ONNX / libtorch. This runtime ports it
+to **ggml + GGUF** so it can run CPU-only, offline, embedded in a C/C++ app, with
+quantized weights. Use it on laptops / phones / edge boxes where there is no GPU
+and no Python. (For high-QPS GPU serving, the PyTorch/vLLM path is still the way.)
+
+## Architecture
+
+SenseVoiceSmall = **SAN-M encoder (70 layers) + CTC head** — no LLM, no autoregression.
+The whole pipeline runs in C++:
 
 ```
-WAV (16k mono) → kaldi fbank → prepend 4 query tokens → SAN-M encoder (ggml) →
-CTC head → greedy CTC decode → token ids → SentencePiece detok → text
+ audio.wav (16k mono)
+      │  kaldi 80-mel fbank + LFR                         (C++)
+      ▼
+   features [T, 560]
+      │  prepend 4 query tokens [lang, event, emotion, itn]
+      ▼
+   [4 + T, 560]
+      │  SAN-M encoder                                    (ggml)  ── sensevoice-small.gguf
+      ▼
+   encoder out [4+T, 512]
+      │  CTC head (Linear 512→25055) → greedy CTC (argmax, dedup, drop blank)
+      ▼
+   token ids
+      │  SentencePiece detok                             (detok.py)
+      ▼
+   <|zh|><|NEUTRAL|><|Speech|><|woitn|> transcription...
 ```
 
-## Contents
-- `funasr-sensevoice/` — the ggml runtime: WAV → CTC token ids
-- `export_sensevoice_gguf.py` — export encoder + CTC head + query embeddings to GGUF
-- `detok.py` — SentencePiece id → text (the bpe model ships with the checkpoint)
+The SAN-M encoder is the same architecture as Fun-ASR-Nano's, so the ggml forward
+is shared between the two runtimes.
 
-## Build
+## Quickstart
+
+**1. Build:**
 ```bash
 git clone https://github.com/ggml-org/llama.cpp && cd llama.cpp
-cp -r /path/to/funasr-sensevoice examples/
+cp -r /path/to/runtime/llama.cpp/funasr-sensevoice examples/
 echo 'add_subdirectory(funasr-sensevoice)' >> examples/CMakeLists.txt
 cmake -B build -DGGML_NATIVE=ON -DLLAMA_CURL=OFF
 cmake --build build -j --target llama-funasr-sensevoice
 ```
 
-## Convert weights to GGUF (one-time)
+**2. Convert weights** (needs the checkpoint, e.g. `FunAudioLLM/SenseVoiceSmall`):
 ```bash
-python export_sensevoice_gguf.py \
+python runtime/llama.cpp/export_sensevoice_gguf.py \
     --model_pt <model>/model.pt --mvn <model>/am.mvn \
-    --out sensevoice-small.gguf                 # f32
-python export_sensevoice_gguf.py --wtype f16 \
+    --out sensevoice-small.gguf                          # f32, ~936 MB
+python runtime/llama.cpp/export_sensevoice_gguf.py --wtype f16 \
     --model_pt <model>/model.pt --mvn <model>/am.mvn \
-    --out sensevoice-small-f16.gguf             # half size
+    --out sensevoice-small-f16.gguf                       # half size
 ```
 
-## Transcribe
+**3. Transcribe:**
 ```bash
 build/bin/llama-funasr-sensevoice -m sensevoice-small.gguf -a audio.wav > ids.txt
-python detok.py <model>/chn_jpn_yue_eng_ko_spectok.bpe.model ids.txt
-# → <|zh|><|NEUTRAL|><|Speech|><|woitn|>...transcription...
+python runtime/llama.cpp/detok.py <model>/chn_jpn_yue_eng_ko_spectok.bpe.model ids.txt
+```
+Expected output:
+```
+<|zh|><|NEUTRAL|><|Speech|><|woitn|>我想问我在滨海新区有房我一直没有照顾孩子...你觉得这是正常的想法吗
+[sensevoice] N=746 (q4+T742) encode 1.32s
+```
+The leading `<|...|>` tags are the predicted language / emotion / event / ITN.
+
+## Accuracy & validation
+
+- **CTC token ids (C++) vs PyTorch:** **identical** (108/108 on a benchmark clip).
+- **Detokenized text:** matches the FunASR `AutoModel` output **exactly**.
+- Encoder validated against PyTorch (shared with Fun-ASR-Nano runtime): cosine 1.0.
+- Encode time ≈ **1.3 s** on CPU for a 44 s clip.
+
+## Tips & gotchas
+
+- **No CMVN at inference.** SenseVoice `inference()` feeds the **raw** log-mel fbank
+  to the encoder; it does **not** apply `am.mvn`. Applying CMVN makes the model
+  predict `<|nospeech|>`. (The export script reads `am.mvn` for completeness but the
+  runtime does not use it.)
+- **Query tokens (4)** are prepended from `embed.weight`, default indices
+  `[language=auto(0), event=1, emotion=2, textnorm=woitn(15)]`. Change them for a
+  fixed language or to enable ITN (`withitn=14`).
+- **WAV input** assumes 16 kHz mono PCM16.
+- LayerNorm eps = 1e-5; FSMN = exact f32 shift-accumulate; fbank matches torchaudio.
+
+## Files
+```
+funasr-sensevoice/        ggml runtime: WAV → CTC token ids
+export_sensevoice_gguf.py export encoder + CTC head + query embeddings to GGUF
+detok.py                  SentencePiece id → text (bpe model ships with the checkpoint)
 ```
 
-## Notes & validation
-- The 70-layer SAN-M encoder is shared with the Fun-ASR-Nano runtime and was
-  validated against PyTorch (cosine 1.0). On a benchmark clip the C++ CTC token
-  ids are **identical** to PyTorch (108/108), and the detokenized text matches
-  the FunASR `AutoModel` output exactly.
-- Inference feeds the **raw** log-mel fbank to the encoder; SenseVoice does **not**
-  apply am.mvn CMVN at inference (doing so makes it predict `<|nospeech|>`).
-- Query tokens prepended (4): `[language(auto=0), event=1, emotion=2, textnorm(woitn=15)]`
-  from `embed.weight`; change indices for language/ITN options.
-- LayerNorm eps 1e-5; FSMN = exact f32 shift-accumulate; fbank matches torchaudio.
-- WAV input currently assumes 16 kHz mono PCM16.
-
-Requires a SenseVoiceSmall checkpoint (e.g. `FunAudioLLM/SenseVoiceSmall`).
+## Roadmap
+- Built-in SentencePiece detok (drop the Python step); arbitrary WAV formats;
+  encoder Q8 quantization; timestamps.

--- a/runtime/llama.cpp/detok.py
+++ b/runtime/llama.cpp/detok.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+"""Detokenize SenseVoice CTC token ids -> text via the SentencePiece bpe model.
+Usage: python detok.py <bpe.model> <ids.txt>   (ids.txt = space-separated ints)
+"""
+import sys
+import sentencepiece as spm
+
+sp = spm.SentencePieceProcessor(model_file=sys.argv[1])
+ids = [int(x) for x in open(sys.argv[2]).read().split()]
+print(sp.decode(ids))

--- a/runtime/llama.cpp/export_sensevoice_gguf.py
+++ b/runtime/llama.cpp/export_sensevoice_gguf.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Export SenseVoiceSmall (encoder + CTC head + query embeddings + CMVN) to GGUF
+for the ggml C++ runtime. The encoder is the same SAN-M architecture as
+Fun-ASR-Nano, so the C++ forward is shared.
+"""
+import argparse, os, re
+import numpy as np, torch, gguf
+
+
+def parse_mvn(path):
+    """am.mvn (kaldi nnet): two `<LearnRateCoef> 0 [ ... ]` blocks -> shift, scale.
+    apply: out = (in + shift) * scale, per-dim (560)."""
+    txt = open(path).read()
+    blocks = re.findall(r"\[([^\]]*)\]", txt)
+    shift = np.array([float(x) for x in blocks[0].split()], dtype=np.float32)
+    scale = np.array([float(x) for x in blocks[1].split()], dtype=np.float32)
+    return shift, scale
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--model_pt", required=True)
+    ap.add_argument("--mvn", required=True)
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--wtype", default="f32", choices=["f32", "f16"])
+    args = ap.parse_args()
+
+    sd = torch.load(args.model_pt, map_location="cpu"); sd = sd.get("state_dict", sd)
+    w = gguf.GGUFWriter(args.out, "sensevoice-small")
+    w.add_uint32("sv.input_size", 560)
+    w.add_uint32("sv.output_size", 512)
+    w.add_uint32("sv.attention_heads", 4)
+    w.add_uint32("sv.num_blocks", 50)
+    w.add_uint32("sv.tp_blocks", 20)
+    w.add_uint32("sv.kernel_size", 11)
+    w.add_uint32("sv.vocab_size", 25055)
+    w.add_uint32("sv.blank_id", 0)
+    # query token embed indices used at inference: [lid(auto=0), 1, 2, textnorm(woitn=15)]
+    w.add_array("sv.query_tokens", [0, 1, 2, 15])
+
+    shift, scale = parse_mvn(args.mvn)
+    w.add_tensor("cmvn.shift", shift)   # (560,)
+    w.add_tensor("cmvn.scale", scale)   # (560,)
+
+    n = 0
+    for k, v in sd.items():
+        if not (k.startswith("encoder.") or k.startswith("ctc.") or k == "embed.weight"):
+            continue
+        arr = v.detach().to(torch.float32).contiguous().numpy()
+        if k.endswith("fsmn_block.weight"):           # (D,1,K) -> (K,D)
+            arr = np.ascontiguousarray(arr[:, 0, :].T)
+        elif args.wtype == "f16" and arr.ndim == 2 and "norm" not in k:
+            arr = arr.astype(np.float16)
+        w.add_tensor(k, arr)
+        n += 1
+    print(f"writing {n} tensors (+cmvn) to {args.out}")
+    w.write_header_to_file(); w.write_kv_data_to_file(); w.write_tensors_to_file(); w.close()
+    print(f"done: {args.out} ({os.path.getsize(args.out)/1e6:.1f} MB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/runtime/llama.cpp/funasr-sensevoice/CMakeLists.txt
+++ b/runtime/llama.cpp/funasr-sensevoice/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(TARGET llama-funasr-sensevoice)
+add_executable(${TARGET} funasr-sensevoice.cpp)
+install(TARGETS ${TARGET} RUNTIME)
+target_link_libraries(${TARGET} PRIVATE ggml ${CMAKE_THREAD_LIBS_INIT})
+target_compile_features(${TARGET} PRIVATE cxx_std_17)

--- a/runtime/llama.cpp/funasr-sensevoice/funasr-sensevoice.cpp
+++ b/runtime/llama.cpp/funasr-sensevoice/funasr-sensevoice.cpp
@@ -27,7 +27,7 @@ static bool read_wav16(const char*path,std::vector<float>&out){
   if(strncmp(wv,"WAVE",4)){fclose(f);return false;} uint16_t ch=1,bits=16; uint32_t sr=16000;
   while(!feof(f)){char id[4]; if(fread(id,1,4,f)!=4)break; uint32_t sz; if(fread(&sz,4,1,f)!=1)break;
     if(!strncmp(id,"fmt ",4)){uint16_t fmt; fread(&fmt,2,1,f); fread(&ch,2,1,f); fread(&sr,4,1,f); fseek(f,6,SEEK_CUR); fread(&bits,2,1,f); if(sz>16)fseek(f,sz-16,SEEK_CUR);}
-    else if(!strncmp(id,"data",4)){int n=sz/(bits/8); std::vector<int16_t> pcm(n); fread(pcm.data(),2,n,f); out.resize(n/ch);
+    else if(!strncmp(id,"data",4)){if(ch<1||bits!=16){fclose(f);fprintf(stderr,"only 16-bit PCM WAV (ch=%u bits=%u)\n",ch,bits);return false;} int n=sz/(bits/8); std::vector<int16_t> pcm(n); fread(pcm.data(),2,n,f); out.resize(n/ch);
       for(int i=0;i<n/ch;i++)out[i]=pcm[i*ch]/32768.0f; fclose(f); if(sr!=16000)fprintf(stderr,"warn: sr %u\n",sr); return true;}
     else fseek(f,sz,SEEK_CUR);}
   fclose(f); return false;
@@ -126,8 +126,8 @@ int main(int argc,char**argv){
     int t=0; fb=compute_fbank(wav,t); T=t;
   } else {
     FILE*f=fopen(fbank_path.c_str(),"rb"); if(!f){fprintf(stderr,"open fbank\n");return 1;}
-    if(fread(&T,4,1,f)!=1||fread(&Fc,4,1,f)!=1)return 1;
-    fb.resize((size_t)T*Fc); if((int)fread(fb.data(),4,fb.size(),f)!=(int)fb.size())return 1; fclose(f);
+    if(fread(&T,4,1,f)!=1||fread(&Fc,4,1,f)!=1){fclose(f);return 1;}
+    fb.resize((size_t)T*Fc); if((int)fread(fb.data(),4,fb.size(),f)!=(int)fb.size()){fclose(f);return 1;} fclose(f);
   }
 
   // NOTE: SenseVoiceSmall inference() feeds the RAW log-mel fbank to the encoder;
@@ -174,5 +174,6 @@ int main(int argc,char**argv){
   printf("\n");
   fprintf(stderr,"[sensevoice] N=%d (q%d+T%d) encode %.2fs\n",N,nq,T,(t1-t0)/1e6);
   ggml_gallocr_free(ga); ggml_free(c); ggml_backend_free(be);
+  if(m.ctx_w) ggml_free(m.ctx_w);
   return 0;
 }

--- a/runtime/llama.cpp/funasr-sensevoice/funasr-sensevoice.cpp
+++ b/runtime/llama.cpp/funasr-sensevoice/funasr-sensevoice.cpp
@@ -1,0 +1,178 @@
+// funasr-sensevoice: SenseVoiceSmall (SAN-M encoder + CTC) on ggml.
+//   fbank.bin (T x 560) -> CMVN -> prepend 4 query tokens -> SAN-M encoder ->
+//   CTC head -> greedy CTC decode -> token ids (stdout).
+// The encoder is the same SAN-M arch as Fun-ASR-Nano (shared forward).
+// Detokenize the printed ids with the SentencePiece bpe model (Python side for now).
+
+#include "ggml.h"
+#include "ggml-cpu.h"
+#include "ggml-alloc.h"
+#include "ggml-backend.h"
+#include "gguf.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <string>
+#include <vector>
+
+static const float LN_EPS = 1e-5f;
+
+// ---- WAV (16k mono PCM16) + kaldi fbank (shared with funasr-cli) ----
+static bool read_wav16(const char*path,std::vector<float>&out){
+  FILE*f=fopen(path,"rb"); if(!f)return false; char r[4]; fread(r,1,4,f);
+  if(strncmp(r,"RIFF",4)){fclose(f);return false;} fseek(f,4,SEEK_CUR); char wv[4]; fread(wv,1,4,f);
+  if(strncmp(wv,"WAVE",4)){fclose(f);return false;} uint16_t ch=1,bits=16; uint32_t sr=16000;
+  while(!feof(f)){char id[4]; if(fread(id,1,4,f)!=4)break; uint32_t sz; if(fread(&sz,4,1,f)!=1)break;
+    if(!strncmp(id,"fmt ",4)){uint16_t fmt; fread(&fmt,2,1,f); fread(&ch,2,1,f); fread(&sr,4,1,f); fseek(f,6,SEEK_CUR); fread(&bits,2,1,f); if(sz>16)fseek(f,sz-16,SEEK_CUR);}
+    else if(!strncmp(id,"data",4)){int n=sz/(bits/8); std::vector<int16_t> pcm(n); fread(pcm.data(),2,n,f); out.resize(n/ch);
+      for(int i=0;i<n/ch;i++)out[i]=pcm[i*ch]/32768.0f; fclose(f); if(sr!=16000)fprintf(stderr,"warn: sr %u\n",sr); return true;}
+    else fseek(f,sz,SEEK_CUR);}
+  fclose(f); return false;
+}
+static const int FS=16000,WINLEN=400,SHIFT=160,NFFT=512,NMEL=80,LFR_M=7,LFR_N=6;
+static const float PREEMPH=0.97f,LOWF=20.0f,HIGHF=8000.0f;
+static inline float melf(float f){return 1127.0f*logf(1.0f+f/700.0f);}
+static void fftc(std::vector<float>&re,std::vector<float>&im,int n){
+  for(int i=1,j=0;i<n;i++){int b=n>>1;for(;j&b;b>>=1)j^=b;j^=b;if(i<j){std::swap(re[i],re[j]);std::swap(im[i],im[j]);}}
+  for(int len=2;len<=n;len<<=1){double a=-2.0*M_PI/len;float wr=cosf(a),wi=sinf(a);
+    for(int i=0;i<n;i+=len){float cr=1,ci=0;for(int k=0;k<len/2;k++){float ur=re[i+k],ui=im[i+k];
+      float vr=re[i+k+len/2]*cr-im[i+k+len/2]*ci,vi=re[i+k+len/2]*ci+im[i+k+len/2]*cr;
+      re[i+k]=ur+vr;im[i+k]=ui+vi;re[i+k+len/2]=ur-vr;im[i+k+len/2]=ui-vi;float nc=cr*wr-ci*wi;ci=cr*wi+ci*wr;cr=nc;}}}
+}
+static std::vector<float> compute_fbank(std::vector<float> wav,int&T_out){
+  for(auto&v:wav)v*=32768.0f; std::vector<float> win(WINLEN);
+  for(int i=0;i<WINLEN;i++)win[i]=0.54f-0.46f*cosf(2.0f*M_PI*i/(WINLEN-1));
+  const int NBIN=NFFT/2+1; float bw=(float)FS/NFFT,ml=melf(LOWF),mh=melf(HIGHF),dm=(mh-ml)/(NMEL+1);
+  std::vector<std::vector<float>> fb(NMEL,std::vector<float>(NBIN,0.0f));
+  for(int m=0;m<NMEL;m++){float L=ml+m*dm,C=ml+(m+1)*dm,R=ml+(m+2)*dm;
+    for(int k=0;k<NBIN;k++){float mf=melf(bw*k); if(mf>L&&mf<R)fb[m][k]=mf<=C?(mf-L)/(C-L):(R-mf)/(R-C);}}
+  int N=wav.size(),T=(N-WINLEN)/SHIFT+1; std::vector<std::vector<float>> feat(T,std::vector<float>(NMEL));
+  std::vector<float> re(NFFT),im(NFFT),fr(WINLEN); const float fl=1.1920929e-07f;
+  for(int t=0;t<T;t++){const float*s=wav.data()+t*SHIFT; double mn=0; for(int i=0;i<WINLEN;i++)mn+=s[i]; mn/=WINLEN;
+    for(int i=0;i<WINLEN;i++)fr[i]=s[i]-(float)mn; for(int i=WINLEN-1;i>0;i--)fr[i]-=PREEMPH*fr[i-1]; fr[0]-=PREEMPH*fr[0];
+    for(int i=0;i<NFFT;i++){re[i]=i<WINLEN?fr[i]*win[i]:0.0f;im[i]=0.0f;} fftc(re,im,NFFT);
+    for(int m=0;m<NMEL;m++){float e=0;for(int k=0;k<NBIN;k++)if(fb[m][k]>0)e+=fb[m][k]*(re[k]*re[k]+im[k]*im[k]); feat[t][m]=logf(e>fl?e:fl);}}
+  const int pad=(LFR_M-1)/2; int Tl=(T+LFR_N-1)/LFR_N; std::vector<std::vector<float>> pd; pd.reserve(T+pad+LFR_M);
+  for(int i=0;i<pad;i++)pd.push_back(feat[0]); for(int t=0;t<T;t++)pd.push_back(feat[t]);
+  while((int)pd.size()<(Tl-1)*LFR_N+LFR_M)pd.push_back(feat[T-1]);
+  int D=LFR_M*NMEL; std::vector<float> out((size_t)Tl*D);
+  for(int i=0;i<Tl;i++)for(int j=0;j<LFR_M;j++)memcpy(&out[(size_t)i*D+j*NMEL],pd[i*LFR_N+j].data(),NMEL*sizeof(float));
+  T_out=Tl; return out;
+}
+
+struct cfg { int d_model=512,n_head=4,num_blocks=50,tp_blocks=20,kernel=11,vocab=25055,blank=0; };
+struct model { cfg c; ggml_context*ctx_w=nullptr; std::map<std::string,ggml_tensor*> t;
+  ggml_tensor* g(const std::string&n){auto it=t.find(n);if(it==t.end()){fprintf(stderr,"missing %s\n",n.c_str());exit(1);}return it->second;} };
+
+static ggml_tensor* lin(ggml_context*c,ggml_tensor*w,ggml_tensor*b,ggml_tensor*x){auto y=ggml_mul_mat(c,w,x);return b?ggml_add(c,y,b):y;}
+static ggml_tensor* lnorm(ggml_context*c,ggml_tensor*x,ggml_tensor*g,ggml_tensor*b){return ggml_add(c,ggml_mul(c,ggml_norm(c,x,LN_EPS),g),b);}
+static ggml_tensor* sanm_attn(ggml_context*c,model&m,const std::string&p,ggml_tensor*x,int T){
+  const int D=m.c.d_model,H=m.c.n_head,dk=D/H,K=m.c.kernel;
+  ggml_tensor*qkv=lin(c,m.g(p+"linear_q_k_v.weight"),m.g(p+"linear_q_k_v.bias"),x); size_t nb1=qkv->nb[1];
+  ggml_tensor*q=ggml_cont(c,ggml_view_2d(c,qkv,D,T,nb1,0));
+  ggml_tensor*k=ggml_cont(c,ggml_view_2d(c,qkv,D,T,nb1,(size_t)D*sizeof(float)));
+  ggml_tensor*v=ggml_cont(c,ggml_view_2d(c,qkv,D,T,nb1,(size_t)2*D*sizeof(float)));
+  const int pad=(K-1)/2; ggml_tensor*fk=m.g(p+"fsmn_block.weight");
+  ggml_tensor*vp=ggml_pad_ext(c,v,0,0,pad,pad,0,0,0,0); ggml_tensor*fsmn=v;
+  for(int j=0;j<K;j++){auto sl=ggml_view_2d(c,vp,D,T,vp->nb[1],(size_t)j*vp->nb[1]);
+    auto wj=ggml_view_1d(c,fk,D,(size_t)j*fk->nb[1]); fsmn=ggml_add(c,fsmn,ggml_mul(c,ggml_cont(c,sl),wj));}
+  q=ggml_permute(c,ggml_reshape_3d(c,q,dk,H,T),0,2,1,3); k=ggml_permute(c,ggml_reshape_3d(c,k,dk,H,T),0,2,1,3);
+  ggml_tensor*vh=ggml_cont(c,ggml_permute(c,ggml_reshape_3d(c,v,dk,H,T),1,2,0,3));
+  ggml_tensor*kq=ggml_soft_max(c,ggml_scale(c,ggml_mul_mat(c,k,q),1.0f/sqrtf((float)dk)));
+  ggml_tensor*o=ggml_cont_2d(c,ggml_permute(c,ggml_mul_mat(c,vh,kq),0,2,1,3),D,T);
+  return ggml_add(c,lin(c,m.g(p+"linear_out.weight"),m.g(p+"linear_out.bias"),o),fsmn);
+}
+static ggml_tensor* sanm_layer(ggml_context*c,model&m,const std::string&p,ggml_tensor*x,int T,bool res){
+  auto r=x; auto h=lnorm(c,x,m.g(p+"norm1.weight"),m.g(p+"norm1.bias"));
+  auto sa=sanm_attn(c,m,p+"self_attn.",h,T); x=res?ggml_add(c,r,sa):sa; r=x;
+  h=lnorm(c,x,m.g(p+"norm2.weight"),m.g(p+"norm2.bias"));
+  h=lin(c,m.g(p+"feed_forward.w_1.weight"),m.g(p+"feed_forward.w_1.bias"),h); h=ggml_relu(c,h);
+  h=lin(c,m.g(p+"feed_forward.w_2.weight"),m.g(p+"feed_forward.w_2.bias"),h); return ggml_add(c,r,h);
+}
+static void add_posenc(std::vector<float>&x,int T,int depth){
+  double inc=log(10000.0)/(depth/2.0-1.0);
+  for(int t=0;t<T;t++){double pos=t+1;for(int i=0;i<depth/2;i++){double its=exp(i*-inc),st=pos*its;
+    x[(size_t)t*depth+i]+=(float)sin(st);x[(size_t)t*depth+depth/2+i]+=(float)cos(st);}}
+}
+
+int main(int argc,char**argv){
+  std::string gguf_path,fbank_path,wav_path;
+  for(int i=1;i<argc;i++){ if(!strcmp(argv[i],"-m")&&i+1<argc)gguf_path=argv[++i];
+    else if(!strcmp(argv[i],"-f")&&i+1<argc)fbank_path=argv[++i];
+    else if(!strcmp(argv[i],"-a")&&i+1<argc)wav_path=argv[++i];
+    else {fprintf(stderr,"usage: %s -m sensevoice.gguf (-a audio.wav | -f fbank.bin)\n",argv[0]);return 1;} }
+  if(gguf_path.empty()||(fbank_path.empty()&&wav_path.empty())){fprintf(stderr,"missing args\n");return 1;}
+
+  // load model
+  model m; gguf_init_params gp={false,&m.ctx_w}; gguf_context*gg=gguf_init_from_file(gguf_path.c_str(),gp);
+  if(!gg){fprintf(stderr,"load gguf failed\n");return 1;}
+  auto rd=[&](const char*k,int d){int i=gguf_find_key(gg,k);return i<0?d:(int)gguf_get_val_u32(gg,i);};
+  m.c.d_model=rd("sv.output_size",512); m.c.n_head=rd("sv.attention_heads",4);
+  m.c.num_blocks=rd("sv.num_blocks",50); m.c.tp_blocks=rd("sv.tp_blocks",20);
+  m.c.kernel=rd("sv.kernel_size",11); m.c.vocab=rd("sv.vocab_size",25055); m.c.blank=rd("sv.blank_id",0);
+  int qi=gguf_find_key(gg,"sv.query_tokens"); int nq=qi<0?0:(int)gguf_get_arr_n(gg,qi);
+  std::vector<int> qtok(nq); for(int i=0;i<nq;i++) qtok[i]=((const int32_t*)gguf_get_arr_data(gg,qi))[i];
+  for(int i=0;i<gguf_get_n_tensors(gg);i++){const char*nm=gguf_get_tensor_name(gg,i);m.t[nm]=ggml_get_tensor(m.ctx_w,nm);}
+  gguf_free(gg);
+  const int F=560, D=m.c.d_model, V=m.c.vocab;
+
+  // fbank [T,F]: from wav (-a) or precomputed (-f)
+  int32_t T=0,Fc=F; std::vector<float> fb;
+  if(!wav_path.empty()){
+    std::vector<float> wav; if(!read_wav16(wav_path.c_str(),wav)){fprintf(stderr,"read wav failed\n");return 1;}
+    int t=0; fb=compute_fbank(wav,t); T=t;
+  } else {
+    FILE*f=fopen(fbank_path.c_str(),"rb"); if(!f){fprintf(stderr,"open fbank\n");return 1;}
+    if(fread(&T,4,1,f)!=1||fread(&Fc,4,1,f)!=1)return 1;
+    fb.resize((size_t)T*Fc); if((int)fread(fb.data(),4,fb.size(),f)!=(int)fb.size())return 1; fclose(f);
+  }
+
+  // NOTE: SenseVoiceSmall inference() feeds the RAW log-mel fbank to the encoder;
+  // it does NOT apply am.mvn CMVN (that path is unused at inference). Applying it
+  // makes the encoder predict <|nospeech|>. So no CMVN here.
+
+  // prepend nq query tokens (rows of embed.weight) -> input [nq+T, F]
+  float*emb=(float*)m.g("embed.weight")->data;   // [16, 560] row-major
+  int N=nq+T; std::vector<float> inp((size_t)N*F);
+  for(int i=0;i<nq;i++) memcpy(&inp[(size_t)i*F], &emb[(size_t)qtok[i]*F], F*sizeof(float));
+  memcpy(&inp[(size_t)nq*F], fb.data(), (size_t)T*F*sizeof(float));
+
+  // encoder pre-scale + posenc
+  float sc=sqrtf((float)D); for(auto&v:inp)v*=sc; add_posenc(inp,N,F);
+
+  // build graph
+  ggml_backend_t be=ggml_backend_cpu_init();
+  ggml_init_params cp={(size_t)1024*1024*1024,nullptr,true}; ggml_context*c=ggml_init(cp);
+  ggml_tensor*x=ggml_new_tensor_2d(c,GGML_TYPE_F32,F,N); ggml_set_input(x);
+  ggml_tensor*h=sanm_layer(c,m,"encoder.encoders0.0.",x,N,false);
+  for(int i=0;i<m.c.num_blocks-1;i++) h=sanm_layer(c,m,"encoder.encoders."+std::to_string(i)+".",h,N,true);
+  h=lnorm(c,h,m.g("encoder.after_norm.weight"),m.g("encoder.after_norm.bias"));
+  for(int i=0;i<m.c.tp_blocks;i++) h=sanm_layer(c,m,"encoder.tp_encoders."+std::to_string(i)+".",h,N,true);
+  h=lnorm(c,h,m.g("encoder.tp_norm.weight"),m.g("encoder.tp_norm.bias"));
+  ggml_tensor*logits=lin(c,m.g("ctc.ctc_lo.weight"),m.g("ctc.ctc_lo.bias"),h);  // [V, N]
+  ggml_set_output(logits);
+  ggml_cgraph*gf=ggml_new_graph_custom(c,32768,false); ggml_build_forward_expand(gf,logits);
+  ggml_gallocr_t ga=ggml_gallocr_new(ggml_backend_cpu_buffer_type()); ggml_gallocr_alloc_graph(ga,gf);
+  ggml_backend_tensor_set(x,inp.data(),0,ggml_nbytes(x));
+  ggml_backend_cpu_set_n_threads(be,8);
+  int64_t t0=ggml_time_us();
+  if(ggml_backend_graph_compute(be,gf)!=GGML_STATUS_SUCCESS){fprintf(stderr,"compute failed\n");return 1;}
+  int64_t t1=ggml_time_us();
+
+  std::vector<float> lg((size_t)V*N); ggml_backend_tensor_get(logits,lg.data(),0,ggml_nbytes(logits));
+  // greedy CTC: argmax per frame -> collapse consecutive -> drop blank
+  int prev=-1;
+  for(int n=0;n<N;n++){
+    const float*col=&lg[(size_t)n*V]; int am=0; float best=col[0];
+    for(int v=1;v<V;v++) if(col[v]>best){best=col[v];am=v;}
+    if(am!=prev && am!=m.c.blank) printf("%d ", am);
+    prev=am;
+  }
+  printf("\n");
+  fprintf(stderr,"[sensevoice] N=%d (q%d+T%d) encode %.2fs\n",N,nq,T,(t1-t0)/1e6);
+  ggml_gallocr_free(ga); ggml_free(c); ggml_backend_free(be);
+  return 0;
+}


### PR DESCRIPTION
## SenseVoiceSmall on llama.cpp / GGUF

Run SenseVoiceSmall (SAN-M encoder + CTC, no LLM) on the llama.cpp / ggml stack —
CPU / edge, a single binary, no Python at runtime.

### What's added (`runtime/llama.cpp/`)
- `funasr-sensevoice` — WAV → CTC token ids (ggml)
- `export_sensevoice_gguf.py` — export encoder + CTC head + query embeddings to GGUF
- `detok.py` — SentencePiece id → text
- README with architecture, quickstart, accuracy and gotchas

### How it works
fbank (C++) → prepend 4 query tokens → SAN-M encoder (ggml) → CTC head → greedy CTC
decode → SentencePiece detok. The SAN-M encoder is shared with the Fun-ASR-Nano runtime.

### Validation
- CTC token ids (C++) vs PyTorch: identical (108/108 on a benchmark clip)
- Detokenized text matches the FunASR AutoModel output exactly
- Encode time ≈ 1.3 s on CPU for a 44 s clip

### Notes
- Inference feeds the raw log-mel fbank; SenseVoice does NOT apply am.mvn CMVN at
  inference (applying it makes the model predict <|nospeech|>) — documented in the README.
- WAV input assumes 16 kHz mono PCM16 for now.
- Does not modify any existing code; everything is under `runtime/llama.cpp/`.
