### PR TITLE
fix: detok review findings (null vocab guard + utf-8 tokens read)

### DIFF
--- a/runtime/llama.cpp/funasr-sensevoice/funasr-sensevoice.cpp
+++ b/runtime/llama.cpp/funasr-sensevoice/funasr-sensevoice.cpp
@@ -123,7 +123,7 @@ int main(int argc,char**argv){
   m.c.kernel=rd("sv.kernel_size",11); m.c.vocab=rd("sv.vocab_size",25055); m.c.blank=rd("sv.blank_id",0);
   int qi=gguf_find_key(gg,"sv.query_tokens"); int nq=qi<0?0:(int)gguf_get_arr_n(gg,qi);
   std::vector<int> qtok(nq); for(int i=0;i<nq;i++) qtok[i]=((const int32_t*)gguf_get_arr_data(gg,qi))[i];
-  std::vector<std::string> vocab; {int ki=gguf_find_key(gg,"sv.vocab"); if(ki>=0){int nv=gguf_get_arr_n(gg,ki); vocab.resize(nv); for(int i=0;i<nv;i++)vocab[i]=gguf_get_arr_str(gg,ki,i);}}
+  std::vector<std::string> vocab; {int ki=gguf_find_key(gg,"sv.vocab"); if(ki>=0){int nv=gguf_get_arr_n(gg,ki); vocab.resize(nv); for(int i=0;i<nv;i++){const char*s=gguf_get_arr_str(gg,ki,i); vocab[i]=s?s:"";}}}
   for(int i=0;i<gguf_get_n_tensors(gg);i++){const char*nm=gguf_get_tensor_name(gg,i);m.t[nm]=ggml_get_tensor(m.ctx_w,nm);}
   gguf_free(gg);
   const int F=560, D=m.c.d_model, V=m.c.vocab;


### PR DESCRIPTION
Addresses the gemini-code-assist findings on the merged in-binary detok (#3004/#302).

- **Null guard on `gguf_get_arr_str`** (funasr-sensevoice.cpp / funasr-paraformer.cpp): a malformed GGUF could return `nullptr` for a vocab element; assigning that to `std::string` is UB. Now coerces to empty string.
- **`tokens.json` read** (export_paraformer_gguf.py): use `with open(..., encoding="utf-8")` — a context manager (no fd leak) and explicit UTF-8 so the non-ASCII tokens load correctly on Windows (default cp1252).

Not changed: adjacent VAD-segment texts are concatenated without a separator — that is intentional for Chinese, where the VAD splits fall mid-utterance and a space would fragment the sentence (CER is unaffected either way). `--ids` still gives raw ids if a caller wants per-segment structure.

Verified: rebuilt, both binaries still print the correct text (sample + full 002).