### PR TITLE
docs(README): refresh What's New with June updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Online Demo:
 
 <a name="What's News"></a>
 # What's New 🔥
+- 2026/06: **SenseVoice on llama.cpp / GGUF** — run it on CPU/edge as a single self-contained binary (whisper.cpp-style), built-in VAD, no Python at runtime. The q8 model is only ~254 MB with the same accuracy. [runtime/llama.cpp/](./runtime/llama.cpp/) · [Releases](../../releases) · [GGUF on Hugging Face](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF)
 - 2026/05: SenseVoice now supports speaker diarization. Use with `vad_model` + `spk_model` + `punc_model` to get per-sentence speaker labels. Requires installing FunASR from source: `pip install git+https://github.com/modelscope/FunASR.git`
 - 2024/11: Add support for timestamp based on the CTC alignment.
 - 2024/7: Added Export Features for [ONNX](./demo_onnx.py) and [libtorch](./demo_libtorch.py), as well as Python Version Runtimes: [funasr-onnx-0.4.0](https://pypi.org/project/funasr-onnx/), [funasr-torch-0.1.1](https://pypi.org/project/funasr-torch/)


### PR DESCRIPTION
Adds the June milestones to What's New (they were missing — last entries were May): the llama.cpp/GGUF CPU/edge runtime, q8 quantized models, prebuilt binaries, and recent releases. Additive only.