### PR TITLE
docs: add Chinese GGUF quickstart entry

### DIFF
--- a/README_zh.md
+++ b/README_zh.md
@@ -44,6 +44,7 @@ SenseVoice 是具有音频理解能力的音频基础模型，包括语音识别
 
 # 最新动态 🔥
 
+- 2026/06: **SenseVoice 支持 llama.cpp / GGUF**，可在 CPU/边缘端以单个自包含二进制运行（类似 whisper.cpp），内置 VAD，运行时无需 Python。q8 模型约 254 MB，精度保持一致。[runtime/llama.cpp/](./runtime/llama.cpp/) · [Releases](../../releases) · [Hugging Face GGUF](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF)
 - 2026/05: SenseVoice 现已支持说话人分离。配合 `vad_model` + `spk_model` + `punc_model` 使用，可获得带说话人标签的逐句结果。需从源码安装 FunASR：`pip install git+https://github.com/modelscope/FunASR.git`
 - 2024/7：新增加导出 [ONNX](./demo_onnx.py) 与 [libtorch](./demo_libtorch.py) 功能，以及 python 版本 runtime：[funasr-onnx-0.4.0](https://pypi.org/project/funasr-onnx/)，[funasr-torch-0.1.1](https://pypi.org/project/funasr-torch/)
 - 2024/7: [SenseVoice-Small](https://www.modelscope.cn/models/iic/SenseVoiceSmall) 多语言音频理解模型开源，支持中、粤、英、日、韩语的多语言语音识别，情感识别和事件检测能力，具有极低的推理延迟。。
@@ -246,6 +247,17 @@ print([rich_transcription_postprocess (i) for i in res])
 备注：Libtorch 模型导出到原模型目录中
 
 </details>
+
+### CPU/边缘端运行：llama.cpp / GGUF（无需 GPU，无需 Python）
+
+SenseVoice 可以作为**单个自包含二进制**运行。这个路径类似 Whisper 的 whisper.cpp，但在中文与粤语场景下更适合 SenseVoice；运行时内置 FSMN-VAD，无需 Python 环境。
+
+```bash
+bash download-funasr-model.sh sensevoice ./gguf
+llama-funasr-sensevoice -m ./gguf/SenseVoiceSmall-f16.gguf --vad ./gguf/fsmn-vad.gguf -a audio.wav
+```
+
+**预编译二进制：** [Releases](../../releases) · **下载与快速开始：** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF 模型：** [Hugging Face](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF) · **文档与 benchmark：** [runtime/llama.cpp/](./runtime/llama.cpp/)
 
 ### 部署
 


### PR DESCRIPTION
## Summary

- Adds the 2026/06 llama.cpp / GGUF update to the Chinese README.
- Adds a Chinese CPU/edge quick-start section for running SenseVoice as a single binary with GGUF + FSMN-VAD.
- Links the existing releases, funasr.com quick start, Hugging Face GGUF model, and `runtime/llama.cpp/` docs.

## Why

The English README already exposes the GGUF path, but the Chinese README did not. This fills the main-language entry point for CPU/edge users who want a whisper.cpp-style SenseVoice runtime without Python at inference time.

## Validation

- `git diff --check`
- Verified `runtime/llama.cpp/` and `runtime/llama.cpp/download-funasr-model.sh` exist
- Content check for the new GGUF/funasr.com/Hugging Face links
