### PR TITLE
docs: update FunASR clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ fastapi run --port 50000
 ### Requirements
 
 ```shell
-git clone https://github.com/alibaba/FunASR.git && cd FunASR
+git clone https://github.com/modelscope/FunASR.git && cd FunASR
 pip3 install -e ./
 ```
 ## 🐳 Docker Support

--- a/README_ja.md
+++ b/README_ja.md
@@ -243,7 +243,7 @@ fastapi run --port 50000
 ### トレーニング環境のインストール
 
 ```shell
-git clone https://github.com/alibaba/FunASR.git && cd FunASR
+git clone https://github.com/modelscope/FunASR.git && cd FunASR
 pip3 install -e ./
 ```
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -273,7 +273,7 @@ fastapi run --port 50000
 ### 安装训练环境
 
 ```shell
-git clone https://github.com/alibaba/FunASR.git && cd FunASR
+git clone https://github.com/modelscope/FunASR.git && cd FunASR
 pip3 install -e ./
 ```
 


### PR DESCRIPTION
## Summary
- update SenseVoice training-environment clone commands from `alibaba/FunASR` to the current `modelscope/FunASR` repository
- keep the English, Chinese, and Japanese READMEs aligned

## Validation
- `git diff --check`
- README scan confirms no remaining `https://github.com/alibaba/FunASR` or `https://github.com/alibaba-damo-academy/FunASR` links
- changed-line audit confirms only the FunASR clone URL lines changed
