### PR TITLE
deps: update default PyTorch bounds

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-torch<=2.3
-torchaudio
+# Keep the default install outside known Dependabot torch alert ranges.
+# For CUDA-specific wheels, install a matching torch/torchaudio pair first.
+torch>=2.12.1
+torchaudio>=2.11.0
 modelscope
 huggingface
 huggingface_hub


### PR DESCRIPTION
## Summary
- replace the old default `torch<=2.3` bound with `torch>=2.12.1`
- add a modern `torchaudio>=2.11.0` lower bound while leaving CUDA-specific wheel selection to users who preinstall a matching pair
- keep the default `pip install -r requirements.txt` path outside the current Dependabot torch alert ranges reported for `requirements.txt`

## Why
GitHub Dependabot reports 9 open `torch` alerts for the current `requirements.txt`, including a critical `torch.load` advisory fixed in `2.6.0` and newer advisories with ranges up to `<=2.12.0`. The previous `torch<=2.3` default forces new installs into those vulnerable ranges.

## Validation
- `git diff --check`
- requirements scan confirms the old `torch<=2.3` / unbounded `torchaudio` lines are gone
- PyPI metadata check confirms `torch==2.12.1` and `torchaudio==2.11.0` are available
- `pip install --dry-run -r requirements.txt` resolves successfully to `torch-2.12.1`, `torchaudio-2.11.0`, and `funasr-1.3.14`
