### PR TITLE
fix: use safe YAML loader for configs

### DIFF
--- a/utils/infer_utils.py
+++ b/utils/infer_utils.py
@@ -358,7 +358,7 @@ def read_yaml(yaml_path: Union[str, Path]) -> Dict:
         raise FileExistsError(f"The {yaml_path} does not exist.")
 
     with open(str(yaml_path), "rb") as f:
-        data = yaml.load(f, Loader=yaml.Loader)
+        data = yaml.load(f, Loader=yaml.SafeLoader)
     return data
 
 


### PR DESCRIPTION
Switch config parsing from `yaml.Loader` to `yaml.SafeLoader` so model `config.yaml` files are parsed as data only.

This addresses the unsafe deserialization path reported in #311. A crafted YAML file using Python object tags is now rejected by PyYAML instead of being constructed at load time.

Verification run on `ind-gpu8`:
- `python3 -m py_compile utils/infer_utils.py`
- `git diff --check`
- targeted `read_yaml` smoke test with a normal config and a `!!python/object/apply` payload, confirming the latter raises `ConstructorError`
