### PR TITLE
docs: fix SenseVoice GGUF quickstart commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,8 +271,8 @@ Note: Libtorch model is exported to the original model directory.
 Run SenseVoice as a **single self-contained binary** — this is to SenseVoice what [whisper.cpp](https://github.com/ggml-org/whisper.cpp) is to Whisper, but with far stronger Chinese & Cantonese accuracy. Built-in FSMN-VAD, no Python at runtime.
 
 ```bash
-bash download-funasr-model.sh sensevoice ./gguf
-llama-funasr-sensevoice -m ./gguf/SenseVoiceSmall-f16.gguf --vad ./gguf/fsmn-vad.gguf -a audio.wav
+bash runtime/llama.cpp/download-funasr-model.sh sensevoice ./gguf
+llama-funasr-sensevoice -m ./gguf/sensevoice-small-f16.gguf --vad ./gguf/fsmn-vad.gguf -a audio.wav
 ```
 
 **Prebuilt binaries:** [Releases](../../releases) · **Download & quickstart:** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF:** [Hugging Face](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF) · **Docs & benchmarks:** [runtime/llama.cpp/](./runtime/llama.cpp/)

--- a/README_zh.md
+++ b/README_zh.md
@@ -253,8 +253,8 @@ print([rich_transcription_postprocess (i) for i in res])
 SenseVoice 可以作为**单个自包含二进制**运行。这个路径类似 Whisper 的 whisper.cpp，但在中文与粤语场景下更适合 SenseVoice；运行时内置 FSMN-VAD，无需 Python 环境。
 
 ```bash
-bash download-funasr-model.sh sensevoice ./gguf
-llama-funasr-sensevoice -m ./gguf/SenseVoiceSmall-f16.gguf --vad ./gguf/fsmn-vad.gguf -a audio.wav
+bash runtime/llama.cpp/download-funasr-model.sh sensevoice ./gguf
+llama-funasr-sensevoice -m ./gguf/sensevoice-small-f16.gguf --vad ./gguf/fsmn-vad.gguf -a audio.wav
 ```
 
 **预编译二进制：** [Releases](../../releases) · **下载与快速开始：** [funasr.com/llama-cpp](https://www.funasr.com/llama-cpp.html) · **GGUF 模型：** [Hugging Face](https://huggingface.co/FunAudioLLM/SenseVoiceSmall-GGUF) · **文档与 benchmark：** [runtime/llama.cpp/](./runtime/llama.cpp/)


### PR DESCRIPTION
## Summary

- point the cloned-repository quickstart at the tracked download script
- use the case-sensitive GGUF filename published on Hugging Face
- keep the English and Chinese instructions aligned

## Verification

- bash -n runtime/llama.cpp/download-funasr-model.sh
- verified sensevoice-small-f16.gguf through the Hugging Face model API
- checked both READMEs contain no stale root-script or wrong-case filename references
- git diff --check
