### PR TITLE
docs: replace broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,12 +461,11 @@ You can also scan the following DingTalk group QR code to join the community gro
 |:--------------------------------------------------------:|
 | <img src="image/dingding_funasr.png" width="250"/></div> |
 
-<a href="https://star-history.com/#FunAudioLLM/SenseVoice&modelscope/FunASR&FunAudioLLM/Fun-ASR&Date">
+<a href="https://www.star-history.com/FunAudioLLM/SenseVoice">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=FunAudioLLM/SenseVoice,modelscope/FunASR,FunAudioLLM/Fun-ASR&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=FunAudioLLM/SenseVoice,modelscope/FunASR,FunAudioLLM/Fun-ASR&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=FunAudioLLM/SenseVoice,modelscope/FunASR,FunAudioLLM/Fun-ASR&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/badge?repo=FunAudioLLM/SenseVoice&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/badge?repo=FunAudioLLM/SenseVoice" />
+    <img alt="Star History Rank" src="https://api.star-history.com/badge?repo=FunAudioLLM/SenseVoice" />
   </picture>
 </a>
-
 


### PR DESCRIPTION
## Summary

- replace the now-404 multi-repository Star History chart with Star History's current official repository rank badge
- preserve the existing light/dark `<picture>` behavior
- link directly to the SenseVoice Star History page without embedding any access token

GitHub restricted historical stargazer access in July 2026, which broke tokenless live history charts: https://www.star-history.com/blog/github-stargazer-api-restriction/

## Verification

- README parses with `markdown-it` CommonMark
- light and dark badge endpoints return HTTP 200 with `image/svg+xml`
- target Star History page returns HTTP 200
- `git diff --check`
