### PR TITLE
docs: include canonical MIT license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,20 @@
-Ref to https://github.com/modelscope/FunASR?tab=readme-ov-file#license
+MIT License
+Copyright (c) 2025 FunASR
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.


### PR DESCRIPTION
## Summary

- replace the link-only LICENSE placeholder with the MIT text it already references from modelscope/FunASR
- keep the existing license terms and copyright attribution unchanged
- make the repository license machine-readable for GitHub and downstream tooling

## Verification

- normalized byte comparison against modelscope/FunASR LICENSE: passed (only the final newline differs)
- MIT marker validation: passed
- git diff --check: passed
