### PR TITLE
docs: clarify source and model licenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,11 @@ SenseVoice is part of the **FunAudioLLM** family:
 | [CosyVoice](https://github.com/FunAudioLLM/CosyVoice) | Natural speech generation — multi-language, zero-shot cloning | [![](https://img.shields.io/github/stars/FunAudioLLM/CosyVoice?style=social)](https://github.com/FunAudioLLM/CosyVoice) |
 | [FunClip](https://github.com/modelscope/FunClip) | AI-powered video clipping with speech recognition | [![](https://img.shields.io/github/stars/modelscope/FunClip?style=social)](https://github.com/modelscope/FunClip) |
 
+## License
+
+- Source code in this repository is licensed under the [MIT License](./LICENSE).
+- Model weights are distributed separately and follow the terms on each model card. The official [SenseVoiceSmall model card](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) links to the [FunASR Model Open Source License Agreement](https://github.com/modelscope/FunASR/blob/main/MODEL_LICENSE); other artifacts and conversions may list different terms, so check their model cards before use.
+
 <a name="Community"></a>
 # Community
 If you encounter problems in use, you can directly raise Issues on the github page.
@@ -468,4 +473,3 @@ You can also scan the following DingTalk group QR code to join the community gro
     <img alt="Star History Rank" src="https://api.star-history.com/badge?repo=FunAudioLLM/SenseVoice" />
   </picture>
 </a>
-

--- a/README_zh.md
+++ b/README_zh.md
@@ -409,6 +409,12 @@ python webui.py
 - [流式SenseVoice](https://github.com/pengzhendong/streaming-sensevoice)，通过分块（chunk）的方式进行推理，为了实现伪流式处理，采用了截断注意力机制（truncated attention），牺牲了部分精度。此外，该技术还支持CTC前缀束搜索（CTC prefix beam search）以及热词增强功能。
 - [OmniSenseVoice](https://github.com/lifeiteng/OmniSenseVoice) 轻量化推理库，支持batch推理。
 - [SenseVoice Hotword](https://www.modelscope.cn/models/dengcunqin/SenseVoiceSmall_hotword)，神经网络热词增强，[WeNet 中开源基于 CPPN 的神经网络热词增强](https://mp.weixin.qq.com/s/1QkIvh8j7rrUjRyWOgAvdA)。
+
+## 许可证
+
+- 本仓库源码采用 [MIT License](./LICENSE)。
+- 模型权重单独发布，并以各模型卡标注的条款为准。官方 [SenseVoiceSmall 模型卡](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) 链接至 [FunASR 模型开源协议](https://github.com/modelscope/FunASR/blob/main/MODEL_LICENSE)；其他制品和转换版本可能标注不同条款，使用前请核对对应模型卡。
+
 # 联系我们
 
 如果您在使用中遇到问题，可以直接在 github 页面提 Issues。欢迎语音兴趣爱好者扫描以下的钉钉群二维码加入社区群，进行交流和讨论。


### PR DESCRIPTION
## Summary
- distinguish the MIT-licensed repository source from separately distributed model weights
- link SenseVoiceSmall users directly to its model card and the applicable FunASR model agreement
- add matching English and Chinese guidance

## Why
This prevents downstream adopters from assuming that the repository MIT license automatically covers SenseVoiceSmall weights.

## Verification
- `git diff --check`
- all new links returned HTTP 200
- Hugging Face API reports `license: other` and the linked FunASR `MODEL_LICENSE` for SenseVoiceSmall