### PR TITLE
docs: link SenseVoice paper from README headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ SenseVoice is a speech foundation model with multiple speech understanding capab
 </h4>
 
 Model Zoo:
-[modelscope](https://www.modelscope.cn/models/iic/SenseVoiceSmall), [huggingface](https://huggingface.co/FunAudioLLM/SenseVoiceSmall)
+[modelscope](https://www.modelscope.cn/models/iic/SenseVoiceSmall), [huggingface](https://huggingface.co/FunAudioLLM/SenseVoiceSmall), [paper](https://arxiv.org/abs/2407.04051)
 
 Online Demo:
 [modelscope demo](https://www.modelscope.cn/studios/iic/SenseVoice), [huggingface space](https://huggingface.co/spaces/FunAudioLLM/SenseVoice)

--- a/README_zh.md
+++ b/README_zh.md
@@ -19,7 +19,7 @@ SenseVoice 是具有音频理解能力的音频基础模型，包括语音识别
 
 </h4>
 
-模型仓库：[modelscope](https://www.modelscope.cn/models/iic/SenseVoiceSmall)，[huggingface](https://huggingface.co/FunAudioLLM/SenseVoiceSmall)
+模型仓库：[modelscope](https://www.modelscope.cn/models/iic/SenseVoiceSmall)，[huggingface](https://huggingface.co/FunAudioLLM/SenseVoiceSmall)，[论文](https://arxiv.org/abs/2407.04051)
 
 在线体验：
 [modelscope demo](https://www.modelscope.cn/studios/iic/SenseVoice), [huggingface space](https://huggingface.co/spaces/FunAudioLLM/SenseVoice)


### PR DESCRIPTION
## Summary
- add the SenseVoice arXiv paper link next to the ModelScope and Hugging Face model links in the English README
- add the same paper link to the Chinese README header block
- keep the top-of-page discovery path aligned while HF model-card metadata updates remain permission-blocked

## Validation
- git diff --check
- targeted README arXiv link assertion