### PR TITLE
Add SenseVoice PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+## Summary
+
+- TODO
+
+## User impact
+
+Who benefits from this change, and what SenseVoice workflow improves?
+
+## Model, API, and runtime impact
+
+- [ ] No model behavior changes.
+- [ ] Affects SenseVoiceSmall ASR output.
+- [ ] Affects emotion, audio-event, or language-tag behavior.
+- [ ] Affects FastAPI, web UI, ONNX, Docker, or examples.
+- [ ] Affects GGUF / llama.cpp runtime assets or docs.
+- [ ] Affects Hugging Face, ModelScope, or model-card routing.
+
+## Validation
+
+- [ ] I ran the relevant tests or commands:
+- [ ] I checked changed README/docs/model links.
+- [ ] I verified affected ASR, emotion/event, API, or runtime behavior with a small audio sample when applicable.
+
+## Screenshots, logs, or transcripts
+
+Add command output, before/after transcripts, emotion/event tags, screenshots, or logs when they help reviewers understand the change.
+
+## Notes for reviewers
+
+Mention known limitations, skipped optional dependencies, or follow-up work.

--- a/tests/test_github_templates.py
+++ b/tests/test_github_templates.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_pull_request_template_keeps_sensevoice_validation_visible():
+    template = ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
+    assert template.exists()
+
+    text = template.read_text()
+    required = [
+        "Summary",
+        "User impact",
+        "Model, API, and runtime impact",
+        "Validation",
+        "Screenshots, logs, or transcripts",
+    ]
+    for marker in required:
+        assert marker in text


### PR DESCRIPTION
## Summary
- add a SenseVoice pull request template focused on user impact, model/API/runtime scope, validation, and transcripts/logs
- add a lightweight regression test so the template stays present and actionable

## Why
SenseVoice changes can affect ASR text, emotion/event tags, FastAPI/web UI/ONNX/Docker paths, or GGUF/model-card routing. The PR template makes the required validation evidence visible before review.

## Validation
- `python3 -m pytest -q tests/test_github_templates.py tests/test_funasr_requirement.py`
- `python3 -m py_compile api.py webui.py demo1.py demo2.py export.py export_meta.py`
- `git diff --cached --check`
