### PR TITLE
docs: clarify SenseVoiceSmall commercial use

### DIFF
--- a/README.md
+++ b/README.md
@@ -462,6 +462,7 @@ SenseVoice is part of the **FunAudioLLM** family:
 
 - Source code in this repository is licensed under the [MIT License](./LICENSE).
 - Model weights are distributed separately and follow the terms on each model card. The official [SenseVoiceSmall model card](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) links to the [FunASR Model Open Source License Agreement](https://github.com/modelscope/FunASR/blob/main/MODEL_LICENSE); other artifacts and conversions may list different terms, so check their model cards before use.
+- The maintainers have provided an [official SenseVoiceSmall license clarification](https://github.com/QwenAudio/SenseVoice/issues/334#issuecomment-5083546605) for the [FunASR Model Open Source License Agreement v1.1](https://github.com/modelscope/FunASR/blob/58830eca4012644aac0c3218c3ccc7d98f003fda/MODEL_LICENSE): Commercial use of the official SenseVoiceSmall weights is permitted when the model license is followed; Section 3 is a responsibility and risk disclaimer rather than an additional non-commercial restriction; and fine-tuned derivative weights may remain private. The Section 2.2 attribution and model-name requirements still apply. This clarification covers the official weights only, so check the terms for third-party conversions and bundled artifacts separately.
 
 <a name="Community"></a>
 # Community

--- a/README_zh.md
+++ b/README_zh.md
@@ -421,6 +421,7 @@ python webui.py
 
 - 本仓库源码采用 [MIT License](./LICENSE)。
 - 模型权重单独发布，并以各模型卡标注的条款为准。官方 [SenseVoiceSmall 模型卡](https://huggingface.co/FunAudioLLM/SenseVoiceSmall) 链接至 [FunASR 模型开源协议](https://github.com/modelscope/FunASR/blob/main/MODEL_LICENSE)；其他制品和转换版本可能标注不同条款，使用前请核对对应模型卡。
+- 维护者已针对 [FunASR 模型开源协议 v1.1](https://github.com/modelscope/FunASR/blob/58830eca4012644aac0c3218c3ccc7d98f003fda/MODEL_LICENSE) 发布 [SenseVoiceSmall 官方许可澄清](https://github.com/QwenAudio/SenseVoice/issues/334#issuecomment-5083546605)：遵守模型协议时，允许商业使用官方 SenseVoiceSmall 权重；第 3 节属于责任和风险免责声明，不构成额外的“禁止商用”限制；微调后的衍生权重可以保持私有。使用、复制、修改或分享模型时，仍需遵守第 2.2 节的署名和模型名称要求。此澄清仅适用于官方权重，第三方转换版本和打包制品仍需分别核对其条款。
 
 # 联系我们
 

--- a/tests/test_license_clarification.py
+++ b/tests/test_license_clarification.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+OFFICIAL_CLARIFICATION = (
+    "https://github.com/QwenAudio/SenseVoice/issues/334#issuecomment-5083546605"
+)
+IMMUTABLE_MODEL_LICENSE = (
+    "https://github.com/modelscope/FunASR/blob/"
+    "58830eca4012644aac0c3218c3ccc7d98f003fda/MODEL_LICENSE"
+)
+
+
+def test_readmes_surface_official_sensevoicesmall_commercial_use_clarification():
+    expected_markers = {
+        "README.md": [
+            "Agreement v1.1",
+            "Commercial use of the official SenseVoiceSmall weights is permitted",
+            "when the model license is followed",
+            "Section 3 is a responsibility and risk disclaimer",
+            "fine-tuned derivative weights may remain private",
+            "Section 2.2 attribution and model-name requirements",
+            "official weights only",
+            "third-party conversions and bundled artifacts separately",
+        ],
+        "README_zh.md": [
+            "模型开源协议 v1.1",
+            "允许商业使用官方 SenseVoiceSmall 权重",
+            "遵守模型协议时",
+            "第 3 节属于责任和风险免责声明",
+            "微调后的衍生权重可以保持私有",
+            "第 2.2 节的署名和模型名称要求",
+            "仅适用于官方权重",
+            "第三方转换版本和打包制品仍需分别核对",
+        ],
+    }
+
+    for relpath, markers in expected_markers.items():
+        text = (ROOT / relpath).read_text()
+        assert OFFICIAL_CLARIFICATION in text, (
+            f"{relpath} is missing the official license clarification"
+        )
+        assert IMMUTABLE_MODEL_LICENSE in text, (
+            f"{relpath} is missing the immutable v1.1 model license"
+        )
+        for marker in markers:
+            assert marker in text, f"{relpath} is missing: {marker}"
+
+
+def test_license_clarification_keeps_code_and_weight_terms_distinct():
+    for relpath in ["README.md", "README_zh.md"]:
+        text = (ROOT / relpath).read_text()
+        assert "https://huggingface.co/FunAudioLLM/SenseVoiceSmall" in text
+        assert "https://github.com/modelscope/FunASR/blob/main/MODEL_LICENSE" in text
+
+    english = (ROOT / "README.md").read_text()
+    chinese = (ROOT / "README_zh.md").read_text()
+    assert "Source code in this repository is licensed under the" in english
+    assert "official SenseVoiceSmall weights are licensed under the MIT" not in english
+    assert "本仓库源码采用" in chinese
+    assert "官方 SenseVoiceSmall 权重采用 MIT" not in chinese


### PR DESCRIPTION
## Summary

- surface the maintainers' official commercial-use clarification from #334 in the English and Chinese License sections
- scope the clarification to the official SenseVoiceSmall weights and the immutable FunASR Model Open Source License Agreement v1.1 revision
- add regression coverage for the commercial-use, private-derivative, attribution, official-weight-only, and third-party-artifact boundaries

## User impact

Product teams evaluating SenseVoiceSmall can now find the repository's official answer without interpreting Section 3 on their own: commercial use is permitted when the model license is followed, while attribution/model-name requirements remain in force.

## Model, API, and runtime impact

- [x] No model behavior changes.
- [ ] Affects SenseVoiceSmall ASR output.
- [ ] Affects emotion, audio-event, or language-tag behavior.
- [ ] Affects FastAPI, web UI, ONNX, Docker, or examples.
- [ ] Affects GGUF / llama.cpp runtime assets or docs.
- [x] Affects Hugging Face, ModelScope, or model-card routing.

## Validation

- [x] I ran the relevant tests or commands:
  - python3 -m pytest -q tests/test_license_clarification.py (2 passed)
  - python3 -m pytest -q (13 passed)
  - python3 -m compileall -q tests
  - git diff --check
- [x] I checked changed README/docs/model links.
  - official #334 clarification: HTTP 200
  - SenseVoiceSmall model card: HTTP 200
  - current model license: HTTP 200
  - immutable v1.1 model license: HTTP 200
- [x] I verified affected ASR, emotion/event, API, or runtime behavior with a small audio sample when applicable. Not applicable: documentation and regression-test only.

## Screenshots, logs, or transcripts

The regression was red-first: the initial test failed because both READMEs lacked the official clarification. A second red-first guard failed until the v1.1 immutable link and legal scope qualifiers were added.

## Notes for reviewers

The wording is limited to the official maintainer response in #334. It does not reinterpret third-party conversions or bundled artifacts, whose terms still need separate review.
